### PR TITLE
Update metersResultText

### DIFF
--- a/Assets/Scripts/HUD.cs
+++ b/Assets/Scripts/HUD.cs
@@ -29,7 +29,7 @@ namespace Helzinko
         public void UpdateResults(int meters, float time)
         {
             timerResultText.SetText("Time survived: <color=#ff5dcc>" + FormattedTime(time) + "</color>");
-            metersResultText.SetText("Meters Rechead: <color=#ff5dcc>" + meters.ToString() + "</color> m");
+            metersResultText.SetText("Meters Reached: <color=#ff5dcc>" + meters.ToString() + "</color> m");
         }
 
         public void UpdateTimer(float time)


### PR DESCRIPTION
Noticed a lil' typo when displaying my (terrible) score:

![Screen_Shot_2022-10-09_at_6_10_09_PM](https://user-images.githubusercontent.com/121322/194788122-5ff12847-cbe1-42b9-a646-c8fe119578df.png)

Fix attached for your consideration 💜 